### PR TITLE
Follow docker-compose build with --force-rm

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Defines docker container for Misago complete with UWSGI server running Misago an
 Python scripts that `./appctl` runs when it needs to create or change `.env` files with configuration.
 
 
+Conserving disk space
+---------------------
+
+Docker overhead on CPU and memory is negligible, but same can't be said about its disk usage. `./appctl` tries to cleanup whenever possible, but to be safe you will have to monitor amount of free space left on your server, and clean up once in a while using commands like `docker-compose image prune`, manually emptying older logs and backups stored in `logs` and `backups` directories.
+
+
 Need help?
 ----------
 

--- a/appctl
+++ b/appctl
@@ -122,7 +122,7 @@ setup() {
     # Ask user what actions to perform
     read -p "Initialize default database? [Y/n]: " initialize_default_database
     # Run docker build
-    docker-compose build --pull
+    docker-compose build --force-rm --pull
     if [ "$initialize_default_database" != "n" ]; then
         docker-compose run --rm misago ./.run initialize_default_database
     fi
@@ -177,7 +177,7 @@ restart_containers() {
 # Rebuild misago container
 rebuild_misago_container() {
     require_setup
-    docker-compose build  --force-rm misago
+    docker-compose build --force-rm misago
     docker-compose stop misago
     docker-compose up --detach misago
 }

--- a/appctl
+++ b/appctl
@@ -122,7 +122,7 @@ setup() {
     # Ask user what actions to perform
     read -p "Initialize default database? [Y/n]: " initialize_default_database
     # Run docker build
-    docker-compose build --force-rm --pull
+    docker-compose build --no-cache --force-rm --pull
     if [ "$initialize_default_database" != "n" ]; then
         docker-compose run --rm misago ./.run initialize_default_database
     fi
@@ -148,7 +148,7 @@ upgrade() {
     echo "Stopping containers for upgrade..."
     docker-compose stop
     create_new_backup
-    docker-compose build --force-rm --pull
+    docker-compose build --no-cache --force-rm --pull
     docker-compose run --rm misago python manage.py migrate
     collectstatic
     echo "Upgrade has been completed, restarting containers..."
@@ -177,8 +177,8 @@ restart_containers() {
 # Rebuild misago container
 rebuild_misago_container() {
     require_setup
-    docker-compose build --force-rm misago
     docker-compose stop misago
+    docker-compose build --force-rm misago
     docker-compose up --detach misago
 }
 

--- a/misago/Dockerfile
+++ b/misago/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.6
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE 1
 ENV PYTHONUNBUFFERED 1
 ENV IN_MISAGO_DOCKER 1
-ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE 1
 
 # Install dependencies in one single command/layer
 RUN wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | apt-key add - && \

--- a/misago/Dockerfile
+++ b/misago/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.6
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE 1
 ENV PYTHONUNBUFFERED 1
 ENV IN_MISAGO_DOCKER 1
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE 1
 
 # Install dependencies in one single command/layer
 RUN wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | apt-key add - && \


### PR DESCRIPTION
This PR adds additional safeguards to reduce the disk space usage by Docker, but as those aren't perfect (and disabling docker cache altogether would be worse), I've resorted to updating our readme to mention this gotcha.

Fixes #42