### PR TITLE
Pass over env_file.save() calls

### DIFF
--- a/wizard/misago.py
+++ b/wizard/misago.py
@@ -21,4 +21,5 @@ def run_misago_wizard(env_file):
     run_timezone_wizard(env_file)
     run_email_wizard(env_file)
 
+    env_file.save()
     print("Misago configuration has been saved to %s" % env_file.path)

--- a/wizard/postgres.py
+++ b/wizard/postgres.py
@@ -28,11 +28,11 @@ def update_postgres_env_file(env_file):
         changes.append("Password:   %s" % env_file["POSTGRES_PASSWORD"])
 
     if changes:
+        env_file.save()
         print(
             "PostgreSQL configuration file has been updated with following database settings:"
         )
         print()
         print("\n".join(changes))
-        env_file.save()
     else:
         print("PostgreSQL configuration file is up to date.")


### PR DESCRIPTION
This PR also re-adds missing `env_file.save()` in main `misago.env` wizard.