### PR TITLE
Fix setup_crontab -> set_crontab

### DIFF
--- a/appctl
+++ b/appctl
@@ -127,7 +127,7 @@ setup() {
         docker-compose run --rm misago ./.run initialize_default_database
     fi
     collectstatic
-    setup_crontab
+    set_crontab
 }
 
 # Run collectstatic (uses misago-static volume) so site has loaded assets


### PR DESCRIPTION
This PR fixes crash when `setup` step tries to execute `setup_crontab` instead of `set_crontab`