### PR TITLE
Fix misc problems found during test deployment

### DIFF
--- a/appctl
+++ b/appctl
@@ -124,10 +124,15 @@ setup() {
     # Run docker build
     docker-compose build --no-cache --force-rm --pull
     if [ "$initialize_default_database" != "n" ]; then
+        docker-compose up --detach misago
         docker-compose run --rm misago ./.run initialize_default_database
     fi
     collectstatic
     set_crontab
+    if [ "$initialize_default_database" != "n" ]; then
+        start_containers
+        echo "Setup complete. Your Misago installation is up and running on your domain."
+    fi
 }
 
 # Run collectstatic (uses misago-static volume) so site has loaded assets

--- a/appctl
+++ b/appctl
@@ -124,13 +124,13 @@ setup() {
     # Run docker build
     docker-compose build --no-cache --force-rm --pull
     if [ "$initialize_default_database" != "n" ]; then
-        docker-compose up --detach misago
+        start_containers
         docker-compose run --rm misago ./.run initialize_default_database
     fi
     collectstatic
     set_crontab
     if [ "$initialize_default_database" != "n" ]; then
-        start_containers
+        restart_containers
         echo "Setup complete. Your Misago installation is up and running on your domain."
     fi
 }

--- a/misago/.run
+++ b/misago/.run
@@ -22,7 +22,7 @@ error() {
 
 
 wait_for_db() {
-    export PGPASSWORD=$POSTGRES_PASSWORD
+    PGPASSWORD=$POSTGRES_PASSWORD
     RETRIES=10
     until psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_USER -c "select 1" > /dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
         ((RETRIES--))
@@ -52,7 +52,7 @@ initialize_default_database() {
 run_psql() {
     wait_for_db
     PGPASSWORD=$POSTGRES_PASSWORD
-    psql --username $POSTGRES_USER --host $POSTGRES_HOST $POSTGRES_DB
+    psql --username $POSTGRES_USER --host $POSTGRES_HOST $POSTGRES_USER
 }
 
 # Backup database and media to archive
@@ -67,7 +67,7 @@ create_new_backup() {
     # backup database
     wait_for_db
     PGPASSWORD=$POSTGRES_PASSWORD
-    pg_dump -U $POSTGRES_USER -h $POSTGRES_HOST $POSTGRES_DB -Oxc > "./$backup_dir/database.sql"
+    pg_dump -U $POSTGRES_USER -h $POSTGRES_HOST $POSTGRES_USER -Oxc > "./$backup_dir/database.sql"
     # backup media
     cp -r /misago/media "$backup_dir/media"
     # archive backup dir
@@ -115,7 +115,7 @@ restore_from_backup() {
     # Restore from archive
     wait_for_db
     PGPASSWORD=$POSTGRES_PASSWORD
-    (psql --username $POSTGRES_USER --host $POSTGRES_HOST $POSTGRES_DB < $database_sql) > /dev/null 2>/dev/null
+    (psql --username $POSTGRES_USER --host $POSTGRES_HOST $POSTGRES_USER < $database_sql) > /dev/null 2>/dev/null
     rm -rf /misago/media/*
     mv "$media_dir"/* /misago/media/
     # Cleanup...

--- a/misago/Dockerfile
+++ b/misago/Dockerfile
@@ -8,8 +8,7 @@ ENV IN_MISAGO_DOCKER 1
 RUN wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | apt-key add - && \
     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >> /etc/apt/sources.list.d/pgdg.list' && \
     apt-get update && \
-    apt-get install -y \
-      apt-utils \
+    apt-get install -y --allow-unauthenticated \
       vim \
       libffi-dev \
       libssl-dev \

--- a/misago/misagodocker/settings.py
+++ b/misago/misagodocker/settings.py
@@ -47,7 +47,7 @@ DATABASES = {
     'default': {
         # Misago requires PostgreSQL to run
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ.get('POSTGRES_DB') or os.environ.get('POSTGRES_USER'),
+        'NAME': os.environ.get('POSTGRES_USER'),
         'USER': os.environ.get('POSTGRES_USER'),
         'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
         'HOST': os.environ.get('POSTGRES_HOST'),

--- a/wizard/postgres.py
+++ b/wizard/postgres.py
@@ -9,8 +9,8 @@ def run_postgres_wizard(env_file):
 
 
 def generate_default_postgres_env_file(env_file):
-    env_file["POSTGRES_USER"] = "misago%s" % get_random_string(16)
-    env_file["POSTGRES_PASSWORD"] = "%s" % get_random_string(100)
+    env_file["POSTGRES_USER"] = "misago_%s" % get_random_string(16)
+    env_file["POSTGRES_PASSWORD"] = "%s" % get_random_string(80)
     env_file.save()
 
     print("PostgreSQL configuration has been saved to %s" % env_file.path)
@@ -20,11 +20,11 @@ def update_postgres_env_file(env_file):
     changes = []
 
     if not env_file.get("POSTGRES_USER"):
-        env_file["POSTGRES_USER"] = "misago%s" % get_random_string(16)
+        env_file["POSTGRES_USER"] = "misago_%s" % get_random_string(16)
         changes.append("User:       %s" % env_file["POSTGRES_USER"])
 
     if not env_file.get("POSTGRES_PASSWORD"):
-        env_file["POSTGRES_PASSWORD"] = "%s" % get_random_string(100)
+        env_file["POSTGRES_PASSWORD"] = "%s" % get_random_string(80)
         changes.append("Password:   %s" % env_file["POSTGRES_PASSWORD"])
 
     if changes:


### PR DESCRIPTION
This PR contains fixes and tweaks for issues that I've found installing Misago on DO droplet with Docker:

- [x] Shortened PostgreSQL password to 80 characters as default docker image no longer supports passwords of length 100+
- [x] Added start and restart containers before different steps in `./appctl setup`
- [x] Removed `$POSTGRES_DB` variable from misago container
- [x] Added `--allow-unauthenticated` to Misago's `Dockerfile`