### PR TITLE
Delete automatic backups older than 21 days, and all logs older than 60 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Conserving disk space
 
 Docker overhead on CPU and memory is negligible, but same can't be said about its disk usage. `./appctl` tries to cleanup whenever possible, but to be safe you will have to monitor amount of free space left on your server, and clean up once in a while using commands like `docker-compose image prune`, manually emptying older logs and backups stored in `logs` and `backups` directories.
 
+Default cron task will also try to delete log files older than 60 days, and backup files that are older than 21 days, and have filename starting with `auto-`.
+
 
 Need help?
 ----------

--- a/appctl
+++ b/appctl
@@ -274,7 +274,7 @@ reset_secret_key() {
 # Create new backup
 create_new_backup() {
     require_setup
-    docker-compose run --rm misago ./.run backup
+    docker-compose run --rm misago ./.run backup manual
 }
 
 # Restore from backup

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,40 +1,6 @@
 version: '3.0'
 services:
 
-  nginx-proxy:
-    image: jwilder/nginx-proxy
-    restart: always
-    networks:
-      - misago
-    ports:
-      - "80:80"
-      - "443:443"
-    environment:
-      - ENABLE_IPV6=true
-    labels:
-      com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy: "true"
-    volumes:
-      - nginx-certs:/etc/nginx/certs
-      - nginx-html:/usr/share/nginx/html
-      - misago-media:/misago/media
-      - misago-static:/misago/static
-      - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ./config/vhost.d:/etc/nginx/vhost.d:z
-      - ./logs/nginx:/var/log/nginx:z
-
-  nginx-lets-encrypt:
-    image: jrcs/letsencrypt-nginx-proxy-companion
-    restart: always
-    networks:
-      - misago
-    depends_on:
-      - nginx-proxy
-    volumes:
-      - nginx-certs:/etc/nginx/certs
-      - nginx-html:/usr/share/nginx/html
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./config/vhost.d:/etc/nginx/vhost.d:z
-
   postgres:
     image: postgres:10
     restart: unless-stopped
@@ -67,7 +33,6 @@ services:
       - ./config/misago.env
       - ./config/postgres.env
     depends_on:
-      - nginx-lets-encrypt
       - postgres
       - redis
     volumes:

--- a/misago/.run
+++ b/misago/.run
@@ -22,7 +22,7 @@ error() {
 
 
 wait_for_db() {
-    PGPASSWORD=$POSTGRES_PASSWORD
+    export PGPASSWORD=$POSTGRES_PASSWORD
     RETRIES=10
     until psql -h $POSTGRES_HOST -U $POSTGRES_USER -d $POSTGRES_USER -c "select 1" > /dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
         ((RETRIES--))
@@ -51,32 +51,32 @@ initialize_default_database() {
 # Run psql connected to database
 run_psql() {
     wait_for_db
-    PGPASSWORD=$POSTGRES_PASSWORD
     psql --username $POSTGRES_USER --host $POSTGRES_HOST $POSTGRES_USER
 }
 
 # Backup database and media to archive
 create_new_backup() {
-    # create backups/year/month path if doesnt exist, and cd to it
-    backups_dir="/misago/backups/$(date +%Y)/$(date +%m)"
-    mkdir -p $backups_dir
-    cd $backups_dir
-    # create backup dir
-    backup_dir="misago-$(date +%Y%m%d%H%M%S)"
+    cd "/misago/backups/"
+    if [[ $1 ]]; then
+        backup_type="$1"
+    else
+        backup_type="auto"
+    fi
+    # create tmp backup dir
+    backup_dir="$backup_type-$(date +%Y%m%d%H%M%S)"
     mkdir "./$backup_dir"
     # backup database
     wait_for_db
-    PGPASSWORD=$POSTGRES_PASSWORD
     pg_dump -U $POSTGRES_USER -h $POSTGRES_HOST $POSTGRES_USER -Oxc > "./$backup_dir/database.sql"
     # backup media
     cp -r /misago/media "$backup_dir/media"
     # archive backup dir
-    backup_archive="misago-$(date +%Y%m%d%H%M%S).tar.gz"
+    backup_archive="$backup_type-$(date +%Y%m%d%H%M%S).tar.gz"
     GZIP=-9
     tar -zcf $backup_archive "./$backup_dir"
     # delete backup dir as its no longer required
     rm -rf $backup_dir
-    echo "New backup has been created at backups/$(date +%Y)/$(date +%m)/$backup_archive"
+    echo "New backup has been created at backups/$backup_archive"
     echo
 }
 
@@ -114,7 +114,6 @@ restore_from_backup() {
     fi
     # Restore from archive
     wait_for_db
-    PGPASSWORD=$POSTGRES_PASSWORD
     (psql --username $POSTGRES_USER --host $POSTGRES_HOST $POSTGRES_USER < $database_sql) > /dev/null 2>/dev/null
     rm -rf /misago/media/*
     mv "$media_dir"/* /misago/media/
@@ -133,7 +132,7 @@ if [[ $1 ]]; then
     elif [[ $1 = "psql" ]]; then
         run_psql
     elif [[ $1 = "backup" ]]; then
-        create_new_backup
+        create_new_backup $2
     elif [[ $1 = "restore" ]]; then
         restore_from_backup $2
     else

--- a/misago/cron
+++ b/misago/cron
@@ -15,6 +15,12 @@
 # Make sure database is available
 ./.run wait_for_db
 
+# Remove logs older than 60 days
+find /misago/logs/ -mindepth 1 -type f -mtime +60 -delete
+
+# Remove backups older than 21 days
+find /misago/backups/ -name auto-* -type f -mtime +21 -delete
+
 # Create daily backup
 if [[ $MISAGO_DAILY_BACKUP = "yes" ]]; then
     ./.run backup


### PR DESCRIPTION
This PR:

- uses different prefix for backups created manually and automatically
- deletes automatic backups older than 21 days
- deletes all log files older than 60 days
- fixes bug in `wait_for_db` not exposing the `PGPASSWORD` for proceeding PG commands

Fixes #54 