### PR TITLE
Improve docker availability check

### DIFF
--- a/appctl
+++ b/appctl
@@ -30,12 +30,22 @@ require_setup() {
     done
 }
 
-# Check if user has docker-compose
-if ! command -v docker-compose >/dev/null 2>&1; then
+# Check if user has docker and docker-compose
+if ! command -v docker >/dev/null 2>&1; then
     error "You need to have Docker installed to use this tool."
     echo
     echo "Docker release for your system can be downloaded for free from this page:"
     echo "https://www.docker.com/get-started"
+    echo
+    echo "If you are on Linux, you will also have to install Docker Compose:"
+    echo "https://docs.docker.com/compose/install/"
+    echo
+    exit 1
+elif ! command -v docker-compose >/dev/null 2>&1; then
+    error "You need to have Docker Compose installed to use this tool."
+    echo
+    echo "Docker Compose release for your system can be downloaded for free from this page:"
+    echo "https://docs.docker.com/compose/install/"
     echo
     exit 1
 fi

--- a/appctl
+++ b/appctl
@@ -37,14 +37,14 @@ if ! command -v docker >/dev/null 2>&1; then
     echo "Docker release for your system can be downloaded for free from this page:"
     echo "https://www.docker.com/get-started"
     echo
-    echo "If you are on Linux, you will also have to install Docker Compose:"
+    echo "If you are on Linux, you will also have to install Docker Compose after installing Docker:"
     echo "https://docs.docker.com/compose/install/"
     echo
     exit 1
 elif ! command -v docker-compose >/dev/null 2>&1; then
     error "You need to have Docker Compose installed to use this tool."
     echo
-    echo "Docker Compose release for your system can be downloaded for free from this page:"
+    echo "Guide for installing Docker Compose on your system can be found on this page:"
     echo "https://docs.docker.com/compose/install/"
     echo
     exit 1


### PR DESCRIPTION
Note that Docker Compose has to be installed in addition to Docker, and add a dedicated check for `docker-compose` availability in case that Docker is installed without Compose.