### PR TITLE
Update lets encrypt proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,13 +23,14 @@ services:
       - ./logs/nginx:/var/log/nginx:z
 
   nginx-lets-encrypt:
-    image: jrcs/letsencrypt-nginx-proxy-companion
+    image: jrcs/letsencrypt-nginx-proxy-companion:2
     restart: always
     networks:
       - misago
     depends_on:
       - nginx-proxy
     volumes:
+      - lets-encrypt-acme:/etc/acme.sh
       - nginx-certs:/etc/nginx/certs
       - nginx-html:/usr/share/nginx/html
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -107,5 +108,6 @@ networks:
 volumes:
   nginx-certs:
   nginx-html:
+  lets-encrypt-acme:
   misago-database:
   misago-redis:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - ./logs/nginx:/var/log/nginx:z
 
   nginx-lets-encrypt:
-    image: jrcs/letsencrypt-nginx-proxy-companion:2
+    image: jrcs/letsencrypt-nginx-proxy-companion:2.0
     restart: always
     networks:
       - misago


### PR DESCRIPTION
This bumps lets encrypt proxy setup to use version 2.0.x, which uses ACMEv2 instead of deprecated v1.