### PR TITLE
Mute write errors in uWSGI

### DIFF
--- a/misago/uwsgi.ini
+++ b/misago/uwsgi.ini
@@ -8,4 +8,7 @@ buffer-size     = 4096
 
 # Enable logging
 log-x-forwarded-for
+ignore-sigpipe
+ignore-write-errors
+disable-write-exception
 logger              = file:/misago/logs/uwsgi.log


### PR DESCRIPTION
When a HTTP connection is closed by client before server completes generating a response to it, a write error is emitted which then gets logged as `OSError write error`.

During traffic spikes on site those errors also spike up, and can clog up 3rd party services, like they currently did clogging misago-project.org's Sentry.

This PR mutes those errors in uwsgi config