### PR TITLE
Remove Docker Compose version following deprecation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.0'
 services:
 
   nginx-proxy:


### PR DESCRIPTION
When spinning this up locally, I'm seeing this warning:

```
WARN[0000] /home/irulan/programs/misago_docker/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

This PR removes that attribute to prevent the deprecation warning from appearing.
